### PR TITLE
refactor(package): add conditional exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "esbuild-plugin-d.ts",
   "version": "1.3.0",
   "main": "./dist/index.js",
-  "exports": "./dist/index.mjs",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs"
+  },
   "types": "./dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
Because in node "the ["exports"](https://nodejs.org/docs/latest-v18.x/api/packages.html#exports) field takes precedence over ["main"](https://nodejs.org/docs/latest-v18.x/api/packages.html#main)" field dual use with commonjs and esmodules is not really possible with that config in package.json. With specifying those conditional exports node is capable of treating it as a commonjs package when imported with require syntax.