### PR TITLE
fix: Use type-fest/TsConfigJson instead of esbuild/TsconfigRaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "chalk": "4.1.2",
     "dts-bundle-generator": "^9.5.1",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "type-fest": "^4.26.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import {TsconfigRaw} from "esbuild";
+import {TsConfigJson} from "type-fest";
 
 export interface DTSPluginOpts {
     /**
@@ -9,7 +9,7 @@ export interface DTSPluginOpts {
     /**
      * path to the tsconfig to use. (some monorepos might need to use this)
      */
-    tsconfig?: string | TsconfigRaw;
+    tsconfig?: string | TsConfigJson;
     /**
      * Directory to store build info files in (only if using incremental builds and no tsBuildInfoFile is defined in tsconfig)
      * @default os tmp directory

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export const tsup: Options = {
     target: "node12",
     entry: ["./src/index.ts"],
     format: ["cjs", "esm"],
-    external: ["esbuild", "typescript", "chalk", "tmp"],
+    external: ["esbuild", "typescript", "chalk", "tmp", "type-fest"],
     dts: true,
     clean: true,
     sourcemap: true,


### PR DESCRIPTION
https://github.com/sindresorhus/type-fest contains a maintained and seemingly complete implementation of type definitions for an object resembling tsconfig.json. Could be a fix for #20.